### PR TITLE
feat: add multiple input sources (stdin, clipboard, single file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,42 @@ npx contextcalc . --mode docs
 npx contextcalc . --bars
 ```
 
+## Input Sources
+
+ContextCalc supports multiple input sources for maximum flexibility:
+
+### Directory Analysis (default)
+Analyze entire directories with hierarchical structure:
+```bash
+npx contextcalc ./src --depth 2
+npx contextcalc . --output flat --min-tokens 1000
+```
+
+### Single File Analysis  
+Analyze individual files directly:
+```bash
+npx contextcalc README.md
+npx contextcalc src/cli.ts --metrics tokens
+npx contextcalc package.json --metrics lines,size --no-colors
+```
+
+### Stdin Pipe
+Pipe content from other commands or files:
+```bash
+cat README.md | npx contextcalc
+echo "Your text here" | npx contextcalc --metrics tokens,lines
+git diff | npx contextcalc --metrics tokens --no-colors
+```
+
+### Clipboard Content
+Analyze content directly from your clipboard:
+```bash
+# Copy some text, then analyze it:
+npx contextcalc --from-clipboard
+npx contextcalc --from-clipboard --metrics tokens
+npx contextcalc --from-clipboard --metrics size --no-colors
+```
+
 ## Output Formats
 
 ### Tree View (default)
@@ -111,6 +147,20 @@ npx contextcalc ./docs --mode docs
 
 # Export data for analysis
 npx contextcalc . -o json > analysis.json
+
+# Single file with specific metrics
+npx contextcalc package.json --metrics lines,size
+
+# Clipboard analysis with custom metrics
+npx contextcalc --from-clipboard --metrics tokens
+
+# Stdin with custom formatting  
+cat large-file.txt | npx contextcalc --metrics tokens,lines --no-colors
+
+# Compare different input sources
+npx contextcalc README.md --metrics tokens
+cat README.md | npx contextcalc --metrics tokens
+# Both should show the same token count!
 ```
 
 ## Why contextcalc?

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,8 +9,89 @@ import { formatAsFlat } from './formatters/flatFormatter.js';
 import { AnalysisMode, OutputFormat, TreeSortBy, MetricType } from './types/index.js';
 import type { TreeOptions, MetricSettings } from './types/index.js';
 import { resolveProjectPath, parseFileSize } from './utils/pathUtils.js';
+import { formatFileSize } from './utils/formatUtils.js';
+import { Tokenizer } from './core/tokenizer.js';
 
 const program = new Command();
+
+function buildMetricInfo(tokens: number, lines: number, bytes: number, tokenizer: Tokenizer, metrics: MetricSettings, useColors: boolean): string {
+  const parts = [];
+  
+  if (metrics.showTokens) {
+    parts.push(`${tokenizer.formatTokenCount(tokens)} tokens`);
+  }
+  
+  if (metrics.showLines) {
+    parts.push(`${lines} lines`);
+  }
+  
+  if (metrics.showSize) {
+    parts.push(formatFileSize(bytes));
+  }
+  
+  const info = parts.length > 0 ? `(${parts.join(', ')})` : '';
+  return useColors ? chalk.dim(info) : info;
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let hasData = false;
+    
+    const timeout = setTimeout(() => {
+      if (!hasData) {
+        resolve(''); // No data available, return empty
+      }
+    }, 10); // Very short timeout to detect if data is available
+    
+    process.stdin.on('data', (chunk) => {
+      hasData = true;
+      clearTimeout(timeout);
+      chunks.push(chunk);
+    });
+    
+    process.stdin.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+    
+    process.stdin.on('error', reject);
+  });
+}
+
+async function readClipboard(): Promise<string> {
+  const { exec } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execAsync = promisify(exec);
+  
+  const platform = process.platform;
+  
+  try {
+    if (platform === 'darwin') {
+      const { stdout } = await execAsync('pbpaste');
+      return stdout;
+    } else if (platform === 'linux') {
+      // Try xclip first, then xsel as fallback
+      try {
+        const { stdout } = await execAsync('xclip -selection clipboard -o');
+        return stdout;
+      } catch {
+        const { stdout } = await execAsync('xsel --clipboard --output');
+        return stdout;
+      }
+    } else if (platform === 'win32') {
+      const { stdout } = await execAsync('powershell -command "Get-Clipboard"');
+      return stdout;
+    } else {
+      throw new Error(`Clipboard access not supported on platform: ${platform}`);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not supported')) {
+      throw error;
+    }
+    throw new Error(`Failed to read clipboard: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}
+
 
 program
   .name('contextcalc')
@@ -34,17 +115,114 @@ program
   .option('--no-colors', 'Disable colored output')
   .option('--no-gitignore', 'Ignore .gitignore files')
   .option('--no-default-ignores', 'Disable default ignore patterns')
+  .option('--from-clipboard', 'Read content from system clipboard')
   .action(async (path: string, options) => {
     try {
       const startTime = Date.now();
       
+      // Parse metrics early so it's available for all processing modes
+      const metrics = parseMetrics(options.metrics);
+      
+      // Check if clipboard option is specified
+      if (options.fromClipboard) {
+        try {
+          const content = await readClipboard();
+          
+          if (content.length === 0) {
+            console.log(chalk.yellow('Clipboard is empty.'));
+            return;
+          }
+          
+          const tokenizer = new Tokenizer();
+          
+          const tokens = tokenizer.countTokensFromText(content);
+          const lines = tokenizer.countLines(content);
+          const bytes = Buffer.byteLength(content, 'utf8');
+          
+          // Format output using metrics settings
+          const metricInfo = buildMetricInfo(tokens, lines, bytes, tokenizer, metrics, !options.noColors);
+          if (!options.noColors) {
+            console.log(chalk.blue(`clipboard`) + ' ' + metricInfo);
+          } else {
+            console.log(`clipboard ${metricInfo}`);
+          }
+          
+          tokenizer.dispose();
+          return;
+        } catch (error) {
+          console.error(chalk.red('Error:'), `Failed to read clipboard: ${error instanceof Error ? error.message : 'Unknown error'}`);
+          process.exit(1);
+        }
+      }
+      
+      // Check if input is being piped from stdin
+      if (!process.stdin.isTTY) {
+        const content = await readStdin();
+        
+        // Only process stdin if there's actual content
+        if (content.length > 0) {
+          const tokenizer = new Tokenizer();
+          
+          const tokens = tokenizer.countTokensFromText(content);
+          const lines = tokenizer.countLines(content);
+          const bytes = Buffer.byteLength(content, 'utf8');
+          
+          // Format output using metrics settings
+          const metricInfo = buildMetricInfo(tokens, lines, bytes, tokenizer, metrics, !options.noColors);
+          if (!options.noColors) {
+            console.log(chalk.blue(`stdin`) + ' ' + metricInfo);
+          } else {
+            console.log(`stdin ${metricInfo}`);
+          }
+          
+          tokenizer.dispose();
+          return;
+        }
+      }
+      
       const projectPath = resolveProjectPath(path);
+      
+      // Check if the path is a file instead of a directory
+      const fs = await import('node:fs/promises');
+      let isFile = false;
+      try {
+        const stats = await fs.stat(projectPath);
+        isFile = stats.isFile();
+      } catch (error) {
+        console.error(chalk.red('Error:'), `Cannot access path ${projectPath}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        process.exit(1);
+      }
+      
+      // Handle single file processing
+      if (isFile) {
+        const tokenizer = new Tokenizer();
+        
+        try {
+          const result = await tokenizer.countTokens(projectPath);
+          const stats = await fs.stat(projectPath);
+          const fileName = projectPath.split('/').pop() || projectPath;
+          
+          // Format output using metrics settings
+          const metricInfo = buildMetricInfo(result.tokens, result.lines, stats.size, tokenizer, metrics, !options.noColors);
+          if (!options.noColors) {
+            console.log(chalk.blue(fileName) + ' ' + metricInfo);
+          } else {
+            console.log(`${fileName} ${metricInfo}`);
+          }
+          
+          tokenizer.dispose();
+          return;
+        } catch (error) {
+          console.error(chalk.red('Error:'), `Failed to process file ${projectPath}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+          tokenizer.dispose();
+          process.exit(1);
+        }
+      }
       
       const mode = validateMode(options.mode);
       const outputFormat = validateOutputFormat(options.output);
       const sortBy = validateSortBy(options.sort);
       const maxFileSize = parseFileSize(options.maxSize);
-      const metrics = parseMetrics(options.metrics);
       const isDebug = process.env.DEBUG === '1' || process.env.DEBUG?.toLowerCase() === 'true';
       
       if (isDebug) {

--- a/src/formatters/enhancedTreeFormatter.ts
+++ b/src/formatters/enhancedTreeFormatter.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { TreeSortBy } from '../types/index.js';
 import type { Node, ScanResult, TreeOptions } from '../types/index.js';
+import { formatFileSize } from '../utils/formatUtils.js';
 
 interface TreeContext {
   isLast: boolean[];
@@ -210,20 +211,6 @@ function formatTokenCount(count: number, useColors: boolean): string {
   }
 }
 
-function formatFileSize(bytes: number): string {
-  if (bytes === 0) return '0B';
-  
-  const units = ['B', 'KB', 'MB', 'GB'];
-  const k = 1024;
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  
-  if (i === 0) {
-    return `${bytes}B`;
-  }
-  
-  const size = (bytes / Math.pow(k, i)).toFixed(1);
-  return `${size}${units[i]}`;
-}
 
 function buildFileInfo(tokenCount: string, lines: number, fileSize: string, options: TreeOptions): string {
   const parts = [];

--- a/src/formatters/flatFormatter.ts
+++ b/src/formatters/flatFormatter.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { Node, ScanResult, TreeOptions, FileNode } from '../types/index.js';
+import { formatFileSize } from '../utils/formatUtils.js';
 
 export function formatAsFlat(result: ScanResult, options: TreeOptions): string {
   if (result.nodes.length === 0) {
@@ -140,20 +141,6 @@ function formatTokenCount(count: number, useColors: boolean): string {
   }
 }
 
-function formatFileSize(bytes: number): string {
-  if (bytes === 0) return '0B';
-  
-  const units = ['B', 'KB', 'MB', 'GB'];
-  const k = 1024;
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  
-  if (i === 0) {
-    return `${bytes}B`;
-  }
-  
-  const size = (bytes / Math.pow(k, i)).toFixed(1);
-  return `${size}${units[i]}`;
-}
 
 function buildFileInfo(tokenCount: string, lines: number, fileSize: string, options: TreeOptions): string {
   const parts = [];

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -1,0 +1,13 @@
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0B';
+  
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const k = 1024;
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  
+  if (i === 0) {
+    return `${bytes}B`;
+  }
+  
+  return `${(bytes / Math.pow(k, i)).toFixed(1)}${units[i]}`;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,229 @@
+import { test, expect } from 'bun:test';
+import { spawn } from 'bun';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const CLI_PATH = path.join(__dirname, '../dist/cli.js');
+
+// Helper to run CLI with input and capture output
+async function runCLI(args: string[] = [], stdin?: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = spawn(['node', CLI_PATH, ...args], {
+    stdin: stdin ? 'pipe' : undefined,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (stdin && proc.stdin) {
+    proc.stdin.write(stdin);
+    proc.stdin.end();
+  }
+
+  const result = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+
+  return {
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+    exitCode: result || 0
+  };
+}
+
+// Helper to create a temporary test file
+async function createTempFile(content: string): Promise<string> {
+  const tempDir = await fs.mkdtemp('/tmp/contextcalc-test-');
+  const filePath = path.join(tempDir, 'test.txt');
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+// Cleanup temp files
+async function cleanup(filePath: string): Promise<void> {
+  try {
+    await fs.unlink(filePath);
+    await fs.rmdir(path.dirname(filePath));
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+test('stdin input - basic functionality', async () => {
+  const result = await runCLI([], 'Hello world, this is test content.');
+  
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain('stdin');
+  expect(result.stdout).toContain('tokens');
+  expect(result.stdout).toContain('lines');
+  expect(result.stdout).toContain('B');
+});
+
+test('stdin input - metrics tokens only', async () => {
+  const result = await runCLI(['--metrics', 'tokens'], 'Test content for tokens');
+  
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toMatch(/stdin \(\d+ tokens\)$/);
+  expect(result.stdout).not.toContain('lines');
+  expect(result.stdout).not.toContain('B');
+});
+
+test('stdin input - metrics lines,size only', async () => {
+  const result = await runCLI(['--metrics', 'lines,size'], 'Test content\nwith multiple lines');
+  
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toMatch(/stdin \(\d+ lines, \d+B\)$/);
+  expect(result.stdout).not.toContain('tokens');
+});
+
+test('stdin input - no colors', async () => {
+  const result = await runCLI(['--no-colors'], 'Test content');
+  
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toMatch(/^stdin \(/);
+  // Should not contain ANSI color codes
+  // eslint-disable-next-line no-control-regex
+  expect(result.stdout).not.toMatch(/\x1b\[[0-9;]*m/);
+});
+
+test('stdin input - empty input', async () => {
+  const result = await runCLI([], '');
+  
+  expect(result.exitCode).toBe(0);
+  // Empty input is treated as no stdin, so it falls back to directory analysis
+  expect(result.stdout).toContain('Summary:');
+});
+
+test('single file input - basic functionality', async () => {
+  const tempFile = await createTempFile('This is test file content for single file processing.');
+  
+  try {
+    const result = await runCLI([tempFile]);
+    
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('test.txt');
+    expect(result.stdout).toContain('tokens');
+    expect(result.stdout).toContain('lines');
+    expect(result.stdout).toContain('B');
+  } finally {
+    await cleanup(tempFile);
+  }
+});
+
+test('single file input - metrics tokens only', async () => {
+  const tempFile = await createTempFile('Test file content');
+  
+  try {
+    const result = await runCLI([tempFile, '--metrics', 'tokens']);
+    
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/test\.txt \(\d+ tokens\)$/);
+    expect(result.stdout).not.toContain('lines');
+    expect(result.stdout).not.toContain('B');
+  } finally {
+    await cleanup(tempFile);
+  }
+});
+
+test('single file input - metrics size only', async () => {
+  const tempFile = await createTempFile('Test file content with some length');
+  
+  try {
+    const result = await runCLI([tempFile, '--metrics', 'size']);
+    
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/test\.txt \(\d+B\)$/);
+    expect(result.stdout).not.toContain('tokens');
+    expect(result.stdout).not.toContain('lines');
+  } finally {
+    await cleanup(tempFile);
+  }
+});
+
+test('single file input - non-existent file', async () => {
+  const result = await runCLI(['/non/existent/file.txt']);
+  
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain('Error:');
+  expect(result.stderr).toContain('Cannot access path');
+});
+
+test('single file input - no colors', async () => {
+  const tempFile = await createTempFile('Test content');
+  
+  try {
+    const result = await runCLI([tempFile, '--no-colors']);
+    
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/^test\.txt \(/);
+    // Should not contain ANSI color codes
+    // eslint-disable-next-line no-control-regex
+    expect(result.stdout).not.toMatch(/\x1b\[[0-9;]*m/);
+  } finally {
+    await cleanup(tempFile);
+  }
+});
+
+// Mock clipboard tests (can't easily test real clipboard in CI)
+test('clipboard input - mock platform detection', async () => {
+  // This test verifies that the CLI has the clipboard option
+  const result = await runCLI(['--help']);
+  
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain('--from-clipboard');
+  expect(result.stdout).toContain('Read content from system clipboard');
+});
+
+test('invalid metrics option', async () => {
+  const result = await runCLI(['--metrics', 'invalid'], 'test');
+  
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain('Invalid metric: invalid');
+});
+
+test('metrics option - all valid combinations', async () => {
+  const validMetrics = [
+    'tokens',
+    'lines',
+    'size',
+    'tokens,lines',
+    'tokens,size',
+    'lines,size',
+    'tokens,lines,size',
+    'tokens,lines,size,percentage'
+  ];
+  
+  for (const metrics of validMetrics) {
+    const result = await runCLI(['--metrics', metrics], 'Test content');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('stdin');
+  }
+});
+
+test('buildMetricInfo function behavior through CLI', async () => {
+  // Test that metrics are properly filtered
+  const testContent = 'This is multi-line\ntest content\nfor metric testing';
+  
+  // Test tokens only
+  const tokensResult = await runCLI(['--metrics', 'tokens'], testContent);
+  expect(tokensResult.stdout).toMatch(/stdin \(\d+ tokens\)$/);
+  
+  // Test lines only  
+  const linesResult = await runCLI(['--metrics', 'lines'], testContent);
+  expect(linesResult.stdout).toMatch(/stdin \(\d+ lines\)$/);
+  
+  // Test size only
+  const sizeResult = await runCLI(['--metrics', 'size'], testContent);
+  expect(sizeResult.stdout).toMatch(/stdin \(\d+B\)$/);
+  
+  // Test combination
+  const comboResult = await runCLI(['--metrics', 'tokens,lines'], testContent);
+  expect(comboResult.stdout).toMatch(/stdin \(\d+ tokens, \d+ lines\)$/);
+  expect(comboResult.stdout).not.toContain('B');
+});
+
+test('directory analysis still works (regression test)', async () => {
+  const result = await runCLI(['.', '--depth', '0']);
+  
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain('tokens');
+  expect(result.stdout).toContain('Summary:');
+});


### PR DESCRIPTION
- Add stdin pipe support: `cat file.txt | contextcalc`
- Add clipboard support: `contextcalc --from-clipboard`
- Add single file support: `contextcalc README.md`
- Add --metrics option support for all input modes
- Create shared formatFileSize utility to eliminate code duplication
- Add comprehensive test suite with 15+ new tests
- Update README with new "Input Sources" section and examples
- Cross-platform clipboard support (macOS, Linux, Windows)
- Maintain full backward compatibility with existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)