### PR TITLE
fix: fix formatting in tree mode

### DIFF
--- a/src/formatters/enhancedTreeFormatter.ts
+++ b/src/formatters/enhancedTreeFormatter.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { basename } from 'node:path';
 import { TreeSortBy } from '../types/index.js';
 import type { Node, ScanResult, TreeOptions } from '../types/index.js';
 import { formatFileSize } from '../utils/formatUtils.js';
@@ -75,11 +76,11 @@ function formatEnhancedNode(node: Node, context: TreeContext, options: TreeOptio
   }
   
   if (node.type === 'file') {
-    const fileName = options.colors ? chalk.cyan(node.path) : node.path;
+    const fileName = options.colors ? chalk.cyan(basename(node.path)) : basename(node.path);
     const info = buildFileInfo(tokenCount, node.lines, fileSize, options);
     lines.push(`${prefix}${weightBar}${fileName} ${info}${percentageText}`);
   } else {
-    const folderName = options.colors ? chalk.blue.bold(node.path) : node.path;
+    const folderName = options.colors ? chalk.blue.bold(basename(node.path)) : basename(node.path);
     const info = buildFolderInfo(tokenCount, fileSize, options);
     lines.push(`${prefix}${weightBar}${folderName} ${info}${percentageText}`);
     

--- a/src/formatters/treeFormatter.ts
+++ b/src/formatters/treeFormatter.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { basename } from 'node:path';
 import type { Node, ScanResult, TreeOptions } from '../types/index.js';
 
 interface TreeContext {
@@ -41,11 +42,11 @@ function formatNode(node: Node, context: TreeContext): string[] {
   const tokenCount = formatTokenCount(node.tokens);
   
   if (node.type === 'file') {
-    const fileName = chalk.cyan(node.path);
+    const fileName = chalk.cyan(basename(node.path));
     const info = chalk.dim(`(${tokenCount} tokens, ${node.lines} lines)`);
     lines.push(`${prefix}${fileName} ${info}`);
   } else {
-    const folderName = chalk.blue.bold(node.path);
+    const folderName = chalk.blue.bold(basename(node.path));
     const info = chalk.dim(`(${tokenCount} tokens)`);
     lines.push(`${prefix}${folderName} ${info}`);
     

--- a/test/enhancedTreeFormatter.test.ts
+++ b/test/enhancedTreeFormatter.test.ts
@@ -109,7 +109,7 @@ test('formatAsEnhancedTree with depth 1 shows root plus immediate children', () 
   // Should not show nested children
   expect(output).not.toContain('folder1/file2.js');
   expect(output).not.toContain('folder1/nested');
-  expect(output).not.toContain('folder1/nested/file3.js');
+  expect(output).not.toContain('file3.js');
 });
 
 test('formatAsEnhancedTree with depth 2 shows root plus two levels of children', () => {
@@ -139,10 +139,10 @@ test('formatAsEnhancedTree with depth 2 shows root plus two levels of children',
   expect(output).toContain('. (600 tokens, 1000B) (10.0%)');
   expect(output).toContain('file1.js');
   expect(output).toContain('folder1');
-  expect(output).toContain('folder1/file2.js');
-  expect(output).toContain('folder1/nested');
+  expect(output).toContain('file2.js');
+  expect(output).toContain('nested');
   // Should not show third level
-  expect(output).not.toContain('folder1/nested/file3.js');
+  expect(output).not.toContain('file3.js');
 });
 
 test('formatAsEnhancedTree with unlimited depth shows full tree', () => {
@@ -172,9 +172,9 @@ test('formatAsEnhancedTree with unlimited depth shows full tree', () => {
   expect(output).toContain('. (600 tokens, 1000B) (10.0%)');
   expect(output).toContain('file1.js');
   expect(output).toContain('folder1');
-  expect(output).toContain('folder1/file2.js');
-  expect(output).toContain('folder1/nested');
-  expect(output).toContain('folder1/nested/file3.js');
+  expect(output).toContain('file2.js');
+  expect(output).toContain('nested');
+  expect(output).toContain('file3.js');
 });
 
 test('formatAsEnhancedTree handles empty nodes array', () => {
@@ -231,10 +231,10 @@ test('formatAsEnhancedTree depth boundary behavior is consistent', () => {
 
   // Test that depth n includes exactly n+1 levels (0-indexed)
   const depth3Output = formatAsEnhancedTree(result, createTreeOptions(3));
-  expect(depth3Output).toContain('level1/level2/level3');
-  expect(depth3Output).not.toContain('level1/level2/level3/file.js');
+  expect(depth3Output).toContain('level3');
+  expect(depth3Output).not.toContain('file.js');
 
   const depth4Output = formatAsEnhancedTree(result, createTreeOptions(4));
-  expect(depth4Output).toContain('level1/level2/level3');
-  expect(depth4Output).toContain('level1/level2/level3/file.js');
+  expect(depth4Output).toContain('level3');
+  expect(depth4Output).toContain('file.js');
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Tree views now display only the final file/folder name (basename) instead of full paths, improving readability for deeply nested structures. Existing color highlighting is preserved. Output is otherwise unchanged and there are no API changes.

- Tests
  - Updated test expectations to reflect basename-only labels across various depth scenarios (depth-limited, unlimited, and boundary cases), ensuring consistent verification of the new display format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->