### PR TITLE
Feat/add mdc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![GitHub License](https://img.shields.io/github/license/agentinit/contextcalc)
 ![NPM Unpacked Size](https://img.shields.io/npm/unpacked-size/contextcalc)
 ![NPM Version](https://img.shields.io/npm/v/contextcalc)
-![NPM Downloads](https://img.shields.io/npm/dm/contextcalc)
+![NPM Downloads](https://img.shields.io/npm/d18m/contextcalc)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/agentinit/contextcalc/release.yml?logo=github)
 
 

--- a/src/utils/fileDetector.ts
+++ b/src/utils/fileDetector.ts
@@ -48,7 +48,7 @@ const CODE_EXTENSIONS = new Set([
 ]);
 
 const DOCS_EXTENSIONS = new Set([
-  '.md', '.markdown', '.mdx',
+  '.md', '.markdown', '.mdx', '.mdc',
   '.txt', '.text',
   '.rst', '.adoc', '.asciidoc',
   '.tex', '.latex',

--- a/test/fileDetector.test.ts
+++ b/test/fileDetector.test.ts
@@ -13,6 +13,7 @@ test('isCodeFile identifies code files correctly', () => {
 test('isDocumentationFile identifies documentation files correctly', () => {
   expect(isDocumentationFile('README.md')).toBe(true);
   expect(isDocumentationFile('docs.txt')).toBe(true);
+  expect(isDocumentationFile('.cursorrules.mdc')).toBe(true);
   expect(isDocumentationFile('test.js')).toBe(false);
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * .mdc files are now recognized as documentation, ensuring they’re included in documentation analysis.

* **Documentation**
  * Updated README download badge to display 18-month NPM downloads for clearer long-term usage insights.

* **Tests**
  * Added test coverage to confirm .mdc (including dot-prefixed filenames) is detected as documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->