### PR TITLE
fix: Fix AST grammar loading and improve file counting

### DIFF
--- a/src/core/languages/javascript.ts
+++ b/src/core/languages/javascript.ts
@@ -9,7 +9,8 @@ export const JavaScriptConfig: LanguageConfig = {
 
   loadGrammar: async () => {
     const JSLanguage = await import('tree-sitter-javascript');
-    return JSLanguage.default;
+    // Handle both ESM and CJS module formats
+    return JSLanguage.default || JSLanguage;
   },
 
   extractSymbols: (tree: Parser.Tree, sourceCode: string): ASTSymbol[] => {

--- a/src/core/languages/python.ts
+++ b/src/core/languages/python.ts
@@ -9,7 +9,8 @@ export const PythonConfig: LanguageConfig = {
 
   loadGrammar: async () => {
     const PythonLanguage = await import('tree-sitter-python');
-    return PythonLanguage.default;
+    // Handle both ESM and CJS module formats
+    return PythonLanguage.default || PythonLanguage;
   },
 
   extractSymbols: (tree: Parser.Tree, sourceCode: string): ASTSymbol[] => {

--- a/src/core/languages/typescript.ts
+++ b/src/core/languages/typescript.ts
@@ -9,7 +9,8 @@ export const TypeScriptConfig: LanguageConfig = {
 
   loadGrammar: async () => {
     const TSLanguage = await import('tree-sitter-typescript');
-    return TSLanguage.typescript;
+    // Handle both ESM and CJS module formats
+    return TSLanguage.typescript || TSLanguage.default?.typescript;
   },
 
   extractSymbols: (tree: Parser.Tree, sourceCode: string): ASTSymbol[] => {

--- a/src/formatters/astFormatter.ts
+++ b/src/formatters/astFormatter.ts
@@ -218,6 +218,7 @@ export function formatAsAST(result: ScanResult, options: ASTFormatterOptions): s
   // Add summary
   const totalFiles = result.totalFiles;
   const totalSymbolsCount = countTotalSymbols(result.nodes);
+  const filesWithSymbols = countFilesWithSymbols(result.nodes);
 
   if (lines.length > 0) {
     lines.pop(); // Remove last blank line
@@ -231,8 +232,9 @@ export function formatAsAST(result: ScanResult, options: ASTFormatterOptions): s
 
     const statLines: string[] = [];
 
-    // Main summary
-    const summary = `Found ${totalSymbolsCount} symbols across ${filesProcessed} ${filesProcessed === 1 ? 'file' : 'files'}`;
+    // Main summary - use filesWithSymbols which counts files that have symbols,
+    // not filesProcessed which only counts freshly parsed files (excludes cache hits)
+    const summary = `Found ${totalSymbolsCount} symbols across ${filesWithSymbols} ${filesWithSymbols === 1 ? 'file' : 'files'}`;
     statLines.push(useColors ? chalk.dim(summary) : summary);
 
     // Files skipped information
@@ -314,6 +316,23 @@ function countTotalSymbols(nodes: Node[]): number {
       });
     }
     return nested;
+  }
+
+  nodes.forEach(countInNode);
+  return count;
+}
+
+function countFilesWithSymbols(nodes: Node[]): number {
+  let count = 0;
+
+  function countInNode(node: Node): void {
+    if (node.type === 'file') {
+      if (node.entities && node.entities.length > 0) {
+        count++;
+      }
+    } else {
+      node.children.forEach(countInNode);
+    }
   }
 
   nodes.forEach(countInNode);


### PR DESCRIPTION
Fixed critical bug where AST parsing was failing due to incorrect grammar loading when using ES module imports on CommonJS tree-sitter modules.

Changes:
- Fix grammar loading in TypeScript, JavaScript, and Python language configs to handle both ESM and CJS module formats
- Add cache invalidation when switching to AST output mode
- Fix AST formatter to count files with symbols instead of only freshly parsed files (which excluded cache hits)
- Add countFilesWithSymbols() helper to accurately report files in summary

This fixes the issue where `contextcalc . --output ast` would only show 1 file instead of all parseable code files in the project.

Fixes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Language loaders (JavaScript, Python, TypeScript) now handle both ESM and CJS module formats to avoid load failures.
  * AST cache behavior fixed to avoid reusing incomplete cache entries when AST mode is enabled.

* **Improvements**
  * Formatter now reports symbol summaries by counting files that actually contain symbols, improving accuracy of summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->