### PR TITLE
fix: prevent entities field in cache when AST is disabled

### DIFF
--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -144,7 +144,7 @@ export class DirectoryScanner {
     try {
       const relativePath = relative(this.projectPath, filePath);
       const fileHash = stats.hash;
-      
+
       const cachedEntry = this.cache.get(relativePath, fileHash);
 
       let tokens: number;
@@ -202,13 +202,19 @@ export class DirectoryScanner {
           }
         }
 
-        // Cache the entry with AST entities
-        this.cache.set(relativePath, {
+        // Cache the entry with or without AST entities depending on whether AST is enabled
+        // Only include entities field if AST parsing was attempted
+        const cacheEntry: import('../types/index.js').CacheEntry = {
           hash: fileHash,
           tokens,
-          lines,
-          entities
-        });
+          lines
+        };
+
+        if (this.enableAST) {
+          cacheEntry.entities = entities;
+        }
+
+        this.cache.set(relativePath, cacheEntry);
         this.stats.cacheMisses++;
       }
 


### PR DESCRIPTION
Fixes a bug where cache entries would include the entities field even when AST parsing was not enabled, preventing re-parsing when switching to AST mode.

The cache now only includes the entities field when AST parsing is actually enabled, ensuring that files are properly re-parsed for AST symbols when switching from non-AST to AST output mode.

This resolves an issue where scanning from the project root would find significantly fewer symbols than scanning from a subdirectory due to stale cache entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized cache management to conditionally store AST data based on configuration, reducing cache overhead when AST parsing is disabled.

* **Refactor**
  * Updated cache retrieval logic to properly handle optional AST metadata and cache validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->